### PR TITLE
Add 'bc' package to installation command

### DIFF
--- a/workshops/eda-workshop-lsf/templates/02-lsf-master.yaml
+++ b/workshops/eda-workshop-lsf/templates/02-lsf-master.yaml
@@ -199,7 +199,7 @@ Resources:
               if [ "$OS_NAME" == "\"Rocky Linux\"" ] && [ "$OS_VERSION" == "\"8.9\"" ]; then
                 OS="rocky8"
                 yum clean all
-                yum install -y python3 wget unzip libnsl vim
+                yum install -y python3 wget unzip libnsl vim bc
                 pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-2.0-29.tar.gz
                 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
                 unzip -q awscliv2.zip


### PR DESCRIPTION
Ebroker fails without `bc` package being installed. I added it to the `yum install`

```sh
[which: no bc in (/efs/tools/ibm/lsf/lsf-cluster-1/10.1/linux2.6-glibc2.3-x86_64/etc:/efs/tools/ibm/lsf/lsf-cluster-1/10.1/linux2.6-glibc2.3-x86_64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin)
/efs/tools/ibm/lsf/lsf-cluster-1/10.1/resource_connector/aws/scripts/getAvailableTemplates.sh: line 30: bc: command not found
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
